### PR TITLE
Update sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -3,15 +3,15 @@
 
 # Steps: pull changes from remote repository, stage all changes, commit changes with message 'Updated', push changes to remote repository on branch 'main'.
 
-# Pull changes from remote repository on branch 'main'
-git pull origin main
+# Pull changes from remote repository
+git pull origin
 
 # Stage all changes
-git add .
+git stage .
 
 # Commit changes with message 'Updated'
 git commit -m "Updated"
 
 # Push changes to remote repository on branch 'main'
-git push origin main
+git push
 


### PR DESCRIPTION
This pull request makes a few updates to the `sync-repo.sh` script to simplify the Git commands used for synchronizing the repository. The most important changes include removing the branch specification from the pull and push commands, and replacing `git add .` with `git stage .`.

Changes to Git commands:

* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L6-R16): Removed the branch specification from the `git pull` command to simplify the pull operation.
* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L6-R16): Replaced `git add .` with `git stage .` to stage all changes.
* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L6-R16): Removed the branch specification from the `git push` command to simplify the push operation.